### PR TITLE
deactivate mark after q-eval-region

### DIFF
--- a/q-mode.el
+++ b/q-mode.el
@@ -366,7 +366,8 @@ This marks the PROCESS with a MESSAGE, at a particular time point."
 (defun q-eval-region (start end)
   "Send the region between START and END to the inferior q[con] process."
   (interactive "r")
-  (q-send-string (q-strip (buffer-substring start end))))
+  (q-send-string (q-strip (buffer-substring start end)))
+  (setq deactivate-mark t))
 
 (defun q-eval-line ()
   "Send the current line to the inferior q[con] process."


### PR DESCRIPTION
In commands like kill-ring-save (better known as M-w) that operate interactively on a region
emacs will deactivate the region when the command is complete. Now, q-eval-region behaves
similar to those commands.