### PR TITLE
Remove nefarious (require 'ess) line

### DIFF
--- a/q-mode.el
+++ b/q-mode.el
@@ -466,7 +466,7 @@ This marks the PROCESS with a MESSAGE, at a particular time point."
     (define-key q-mode-map "\C-c\C-c"   'comment-region)
     q-mode-map)
   "Keymap for q major mode.")
-(require 'ess)
+
 ;; menu bars
 (easy-menu-define q-menu q-mode-map
   "Menubar for q script commands"


### PR DESCRIPTION
This call to (require 'ess) snuck in with commit fd9210a454a8faff69df98a73131c1cadec87ade.

If the user doesn't have ess-mode, this causes a crash on package load, and in fact, the call is completely unnecessary since ess-mode isn't a dependency for q-mode.