### PR TITLE
send string with universal arg shows q buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,13 @@ in the buffer to see all the columns.
 The following commands are available to interact with an inferior
 q[con] process/buffer. `C-c C-l` sends a single line, `C-c C-f`
 sends the surrounding function, `C-c C-r` sends the selected region
-and `C-c C-b` sends the whole buffer.  If the source file exists on
-the same machine as the q process, `C-c M-l` can be used to load
-the file associated with the active buffer.
+and `C-c C-b` sends the whole buffer. If prefixed with `C-u C-u`, 
+or pressing `C-c M-l` `C-c M-f` `C-c M-r`respectively, will also 
+switch point to the active q process buffer for direct interaction. 
+
+If the source file exists on the same machine as the q process, 
+`C-c M-l` can be used to load the file associated with the active 
+buffer.
 
 ## Customization
 


### PR DESCRIPTION
`C-u C-c C-[lrf]` reuses existing functions to optionally switch to the Q Shell buffer after sending the string.
Code reuse (DRY) is achieved by centrally extending `q-send-string`.

