### PR TITLE
q-activate-buffer displays it when interactive

### DIFF
--- a/q-mode.el
+++ b/q-mode.el
@@ -232,6 +232,7 @@
 (defun q-activate-buffer (buffer)
   "Set the `q-active-buffer' to the supplied BUFFER."
   (interactive "bactivate buffer: ")
+  (when (called-interactively-p 'any) (display-buffer buffer))
   (setq q-active-buffer buffer))
 
 (defun q-default-args ()


### PR DESCRIPTION
**what**: q-activate-buffer, when called interactively (e.g. `C-c M-RET`, makes the activated `Q-Shell` buffer visible in one of the windows. 

**why**: activated `Q-Shell` buffer should always be visible, for transparency/safety and visual feedback. 
when working with dozens of simultaneously open, mostly buried `Q-Shell` buffers, to make it transparent to the user where the next command will land when she sends the commands interactively. to prevent surprises where the command is sent unintentionally to some forgotten and buried `Q-Shell` buffer that was activated long time ago (personal oops experience, sending to production environment when dev environment was intended)

previously, when user pressed `C-c M-RET` and selected one of the buffers not shown in any window, the activated buffer stayed buried under other buffers tied to that window. when user sent strings to that buried activated buffer, it was not transparent to the user where did the strings go. user could not see the input and output in the buried `Q-Shell` buffer. it required additional manual command to bring that  `Q-Shell` buffer forward. 


