### PR TITLE
Handle nil host user args arguments

### DIFF
--- a/q-mode.el
+++ b/q-mode.el
@@ -275,9 +275,9 @@ command to read the command line arguments from the minibuffer."
                            (read-string "Q command line args: " args))
                    (list host user args))))
 
-  (unless (or (equal user "") (null user)) (setq host (format "%s@%s" user host)))
-  (let* ((args (if (null args) "" args))
-         (host (if (null host) "" host))
+  (unless (equal (or user "") "") (setq host (format "%s@%s" user host)))
+  (let* ((args (or args ""))
+         (host (or host ""))
          (cmd q-program)
          (cmd (if (equal args "") cmd (concat cmd args)))
          (qs (not (equal host "")))

--- a/q-mode.el
+++ b/q-mode.el
@@ -276,9 +276,9 @@ command to read the command line arguments from the minibuffer."
                    (list host user args))))
 
   (unless (equal (or user "") "") (setq host (format "%s@%s" user host)))
-  (let* ((args (or args ""))
+  (let* ((cmd q-program)
+         (args (or args ""))
          (host (or host ""))
-         (cmd q-program)
          (cmd (if (equal args "") cmd (concat cmd args)))
          (qs (not (equal host "")))
          (port (if (with-temp-buffer (setq case-fold-search nil)(string-match "-p *\\([0-9]+\\)" args)) (match-string 1 args) ""))

--- a/q-mode.el
+++ b/q-mode.el
@@ -261,7 +261,7 @@ each level is indented by this amount."
 (defun q (&optional host user args)
   "Start a new q process.
 The optional argument HOST and USER allow the q process to be
-started on a remoate machine.  The optional ARGS argument
+started on a remote machine.  The optional ARGS argument
 specifies the command line args to use when executing q; the
 default ARGS are obtained from the q-init customization
 variables.  In interactive use, a prefix argument directs this
@@ -275,8 +275,10 @@ command to read the command line arguments from the minibuffer."
                            (read-string "Q command line args: " args))
                    (list host user args))))
 
-  (unless (equal user "") (setq host (format "%s@%s" user host)))
-  (let* ((cmd q-program)
+  (unless (or (equal user "") (null user)) (setq host (format "%s@%s" user host)))
+  (let* ((args (if (null args) "" args))
+         (host (if (null host) "" host))
+         (cmd q-program)
          (cmd (if (equal args "") cmd (concat cmd args)))
          (qs (not (equal host "")))
          (port (if (with-temp-buffer (setq case-fold-search nil)(string-match "-p *\\([0-9]+\\)" args)) (match-string 1 args) ""))


### PR DESCRIPTION
The function q has optional arguments `host` `user` and `args`. However, evaluating `(q)` non interactively will result in an error on line 282 evaluating `string-match("-p *\\([0-9]+\\)" nil)` error: `(wrong-type-argument stringp nil)`. This is because there are no checks if `host` `user` and `args` are nil. Checking for `(null host)` and other optional parameters then converting them to "" will solve this issue since the function can handle empty string arguments.