### PR TITLE
Prevent `q-indent-line` from Moving Point to End of Indentation

### DIFF
--- a/q-mode.el
+++ b/q-mode.el
@@ -666,15 +666,20 @@ This marks the PROCESS with a MESSAGE, at a particular time point."
 
 (defun q-indent-line ()
   "Indent current line as q."
-  (let ((indent (condition-case nil
-                    (save-excursion
-                      (forward-line 0)
-                      (or (if (null q-indent-step)
-                              (q-compute-indent-sexp)
-                            (* q-indent-step (q-compute-indent-tab)))
-                          0))
-                  (error 0))))
-    (indent-line-to indent)))
+  (let* ((savep (point))
+         (indent (condition-case nil
+                     (save-excursion
+                       (forward-line 0)
+                       (skip-chars-forward " \t")
+                       (if (>= (point) savep) (setq savep nil))
+                       (or (if (null q-indent-step)
+                               (q-compute-indent-sexp)
+                             (* q-indent-step (q-compute-indent-tab)))
+                           0))
+                   (error 0))))
+    (if savep
+        (save-excursion (indent-line-to indent))
+      (indent-line-to indent))))
 
 (defun q-compute-indent-sexp ()
   "Compute the indent for a line using sexp."


### PR DESCRIPTION
# Why Stop Point from Moving?
The indentation function of other programming major modes such as `nxml-indent-line` do not move the point to end of indent or beginning of the first token. Preventing point from moving in the `q-indent-line` function will bring `q-mode` in line with other emacs programming major modes.

In particular, moving point breaks the behavior of

```emacs-lisp
(setq tab-always-indent 'complete)
```

since tab will evaluate `indent-line-function`, move the point even when there is no change which will then prevent the evaluation of `(completion-at-point)`.

# The Behavior
`q-indent-line` moves the cursor due to evaluating 

```emacs-lisp
(indent-line-to indent)
``` 

which leaves point at end of indentation. We should use

```emacs-lisp
(save-excursion (indent-line-to indent))
``` 

to make sure the cursor stays at the same spot after indentation. For example, evaluating `(q-indent-line)` at point below

``` 
    badlyindented
             ^
```

After:

```
badlyindented
^
```

Expected:

```
badlyindented
         ^
```

moves point after indenting.

The same behavior also happens when the indentation is correct i.e.

before:

```
word
    ^
```

after

```
word
^
```

point changed even when there are no visible text modifications which is confusing.

# The Edge case

An edge case arises when point is before the first token and `save-excursion` will keep it before the first token. For example,

Before:

```
[ (...
     word...
^ 
```

Expected and Current:

```
[ (...
  word...
 ^
```

with : `(save-excursion (indent-line-to indent))`

```
[ (...
  word...
^
```

point will stay at the same spot.
This is why there is an extra logic check with the following two expressions:

```emacs-lisp
(skip-chars-forward " \t")
(if (>= (point) savep) (setq savep nil))
``` 