### PR TITLE
Faulty `q-constant-keywords` regex-opt

### DIFF
--- a/q-mode.el
+++ b/q-mode.el
@@ -547,10 +547,11 @@ This marks the PROCESS with a MESSAGE, at a particular time point."
 
 (defvar q-constant-words
   (eval-when-compile
-    (regexp-opt '(".z.D" ".z.K" ".z.T" ".z.Z" ".z.N" ".z.P" ".z.a" ".z.b" ".z.d" ".z.exit" ".z.f"
-                  ".z.h" ".z.i" ".z.k" ".z.l" ".z.o" ".z.pc" ".z.pg" ".z.ph" ".z.pi"
-                  ".z.po" ".z.pp" ".z.ps" ".z.pw" ".z.s" ".z.t" ".z.ts" ".z.u" ".z.vs"
-                  ".z.w" ".z.x" ".z.z" ".z.n" ".z.p" ".z.ws" ".z.bm") `words))
+    (format "%s\\>"
+            (regexp-opt '(".z.D" ".z.K" ".z.T" ".z.Z" ".z.N" ".z.P" ".z.a" ".z.b" ".z.d" ".z.exit" ".z.f"
+                          ".z.h" ".z.i" ".z.k" ".z.l" ".z.o" ".z.pc" ".z.pg" ".z.ph" ".z.pi"
+                          ".z.po" ".z.pp" ".z.ps" ".z.pw" ".z.s" ".z.t" ".z.ts" ".z.u" ".z.vs"
+                          ".z.w" ".z.x" ".z.z" ".z.n" ".z.p" ".z.ws" ".z.bm") t)))
   "Constants for q mode.")
 
 (defvar q-font-lock-keywords

--- a/q-mode.el
+++ b/q-mode.el
@@ -547,11 +547,10 @@ This marks the PROCESS with a MESSAGE, at a particular time point."
 
 (defvar q-constant-words
   (eval-when-compile
-    (format "%s\\>"
-            (regexp-opt '(".z.D" ".z.K" ".z.T" ".z.Z" ".z.N" ".z.P" ".z.a" ".z.b" ".z.d" ".z.exit" ".z.f"
-                          ".z.h" ".z.i" ".z.k" ".z.l" ".z.o" ".z.pc" ".z.pg" ".z.ph" ".z.pi"
-                          ".z.po" ".z.pp" ".z.ps" ".z.pw" ".z.s" ".z.t" ".z.ts" ".z.u" ".z.vs"
-                          ".z.w" ".z.x" ".z.z" ".z.n" ".z.p" ".z.ws" ".z.bm") t)))
+    (regexp-opt '(".z.D" ".z.K" ".z.T" ".z.Z" ".z.N" ".z.P" ".z.a" ".z.b" ".z.d" ".z.exit" ".z.f"
+                  ".z.h" ".z.i" ".z.k" ".z.l" ".z.o" ".z.pc" ".z.pg" ".z.ph" ".z.pi"
+                  ".z.po" ".z.pp" ".z.ps" ".z.pw" ".z.s" ".z.t" ".z.ts" ".z.u" ".z.vs"
+                  ".z.w" ".z.x" ".z.z" ".z.n" ".z.p" ".z.ws" ".z.bm") `symbols))
   "Constants for q mode.")
 
 (defvar q-font-lock-keywords


### PR DESCRIPTION
# The `q-constant-words` regex-opt

There is an issue with the `q-constant-words` regex-opt. It does not match any string.

If we use `regex-opt` with the `word` parameter, as follows
```emacs-lisp
(regex-opt '("a" "b") `word)
``` 

from the doc string,
>   the resulting regexp is surrounded by \\<\\( and \\)\\>.


## But what does `\<` match?

From https://www.gnu.org/software/emacs/manual/html_node/emacs/Regexp-Backslash.html,  

> '\\<' matches the empty string, but only at the beginning of a word. ‘\\<’ matches at the beginning of the buffer only if a word-constituent character follows.

Remember that word characters only include the upper and lower case alphabetical characters and the numbers. So it **does not include the period `.` character.** However, every word in `q-constant-words` has the prefix `.z.` i.e. they do not start with a word character. Therefore, `\<` cannot match anything.

## Fix

We can fix this by evaluating `regex-opt` with `t` instead of `'word`. This surrounds the resulting expression with `\(\)`. We can then postpend `\>` to the resulting regexexp. 
This expression can match any prefix which is an issue.  But I believe a word ending with exactly `.z.p` or something similar is quite rare.