### PR TITLE
Add Warning About `rlwrap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,7 @@ changed depending on your environment.
 > [!WARNING]
 > The `q-program` cannot use `rlwrap`. The usage of `rlwrap`
 > creates many issues, the most obvious is that the `q)` prompt can
-> no longer be observed. **This issue cannot be avoided when using**
-> **`KDB-X`** since `rlwrap` is
-> [embedded in the executable](https://code.kx.com/kdb-x/releases/release-notes-latest.html#3-embedded-rlwrap)
-> and cannot be turned off.
+> no longer be observed.
 
 Q-mode indents each level based on `q-indent-step`.  To indent code
 based on {}-, ()-, and []-groups instead of equal width tabs, you

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ buffer.
 Specifically, the `q-program` and `q-qcon-program` variables can be
 changed depending on your environment.
 
+> [!WARNING]
+> The `q-program` cannot use `rlwrap`. The usage of `rlwrap`
+> creates many issues, the most obvious is that the `q)` prompt can
+> no longer be observed. **This issue cannot be avoided when using**
+> **`KDB-X`** since `rlwrap` is
+> [embedded in the executable](https://code.kx.com/kdb-x/releases/release-notes-latest.html#3-embedded-rlwrap)
+> and cannot be turned off.
+
 Q-mode indents each level based on `q-indent-step`.  To indent code
 based on {}-, ()-, and []-groups instead of equal width tabs, you
 can set this value to nil.

--- a/q-mode.el
+++ b/q-mode.el
@@ -293,6 +293,8 @@ command to read the command line arguments from the minibuffer."
          (buffer (get-buffer-create (format "*%s*" (q-shell-name host port))))
          (command (if qs "ssh" (getenv "SHELL")))
          (switches (append (if qs (list "-t" host) (list "-c")) (list cmd)))
+         ;; disable kdb-x rlwrap functionality
+         (process-environment (cons "KX_LINE=0" process-environment))
          process)
     (when (called-interactively-p 'any) (pop-to-buffer buffer))
     (when (or current-prefix-arg (not (comint-check-proc buffer)))


### PR DESCRIPTION
`comint-mode` and by extension `q-shell-mode` does not work with the wrapper `rlwrap` that [kdb actively promotes the usage of](https://code.kx.com/q/learn/startingkdb/language/#loading-q). This is because `rlwrap` issues special terminal commands, such as clear current line after cursor, hide cursor, move cursor right and etc., which cannot be handled in `comint-mode`. This leads to the interpreter prompt `q)` disappearing and other strange behaviors such as repeating text as the terminal incrementally insert and echoes text.

 For most interpreters, `comint-mode` sets the `$TERM` environment shell variable to `dumb` which tells the interpreter to **not use special terminal commands** however `rlwrap` ignores shell environments. This issue is even worse now considering that `KDB-X` has `rlwrap` [embedded in the executable](https://code.kx.com/kdb-x/releases/release-notes-latest.html#3-embedded-rlwrap), which means **you cannot disable rlwrap**.

Adding the warning and documenting the issue in the README (and this PR) will be helpful for anyone encountering this issue when using `q-shell-mode`.

PS: We should also make a forum post on KDB-X for a way to turn off `rlwrap`.