### PR TITLE
use q-program instead of hard coded path

### DIFF
--- a/q-mode.el
+++ b/q-mode.el
@@ -704,7 +704,7 @@ updates when a buffer is saved."
        (make-process
         :name "q-flymake" :noquery t :connection-type 'pipe
         :buffer (generate-new-buffer " *q-flymake*")
-        :command (list "~/bin/q" (buffer-file-name))
+        :command (list q-program (buffer-file-name))
         :sentinel
         (lambda (proc _event)
           ;; check that the process has exited (not just suspended)


### PR DESCRIPTION
There's a bug with the hard coded command.

Are we sure we want this flymake cheker? It is very dangerous since it runs arbitrary q files which can be **very expensive**. The q interpreter errors messages are also not always helpful. I have written a [syntax checker](https://github.com/Gchouchou/q-ts-flycheck) using [treesitter](https://github.com/Gchouchou/tree-sitter-q) as backend (a parser for q-code) which doesn't run arbitrary q-code.

Treesitter support requires emacs 29 however and my parser only catches syntax errors.

